### PR TITLE
Update supervisord.conf

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -27,6 +27,7 @@ stdout_logfile=/dev/stdout
 
 [program:octoprint]
 command=octoprint serve --iknowwhatimdoing --basedir /data --host 0.0.0.0
+autorestart=true
 stderr_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
add autorestart to [program:octoprint] so that supervisord will re-spawn octoprint automatically even if it exits with code 0

This will allow users to configure the octoprint restart command to be "killall octoprint"